### PR TITLE
Ermögliche Nutzung von responsive images ohne low-quality image place…

### DIFF
--- a/Resources/views/Macros/responsiveImg.html.twig
+++ b/Resources/views/Macros/responsiveImg.html.twig
@@ -9,6 +9,7 @@
             'transformations_to_widths': {'image_xxs' : '320w'},
             'class': '',
             'lazyload': true,
+            'lqip': true,
             'placeholder_filter': 'image_xxs--blurred',
         } %}
         {% set options = options ? defaultImgOptions|merge(options) : defaultImgOptions %}
@@ -16,7 +17,11 @@
         <img
             {{ helper.sizes(options.sizes, options.lazyload) }}
             {{ helper.srcset(image.url, options.transformations_to_widths, options.lazyload) }}
-            src="{{ thumbor(image.url, options.placeholder_filter) }}"
+            {% if options.lqip %}
+                src="{{ thumbor(image.url, options.placeholder_filter) }}"
+            {% else %}
+                data-src="{{ thumbor(image.url, options.placeholder_filter) }}"
+            {% endif %}
             class="{% if options.lazyload %}lazyload {% endif %}{{ options.class }}"
             {% if image.alt %}
                 title="{{ image.alt }}"
@@ -49,6 +54,7 @@
         'class': '',
         'alt': '',
         'lazyload': true,
+        'lqip': true,
         'placeholder_filter': 'image_xxs--blurred',
     } %}
 
@@ -79,7 +85,11 @@
         {% set image_url = formats.0.image_url %}
         {% if image_url %}
             <img
-                src="{{ thumbor(image_url, options.placeholder_filter) }}"
+                {% if options.lqip %}
+                    src="{{ thumbor(image_url, options.placeholder_filter) }}"
+                {% else %}
+                    data-src="{{ thumbor(image_url, options.placeholder_filter) }}"
+                {% endif %}
                 class="{% if options.lazyload %}lazyload {% endif %}{{ options.class }}"
                 {% if options.alt %}
                     alt="{{ options.alt }}"


### PR DESCRIPTION
…holder (Case 77890)

Prinzipiell sind wir überzeugte Fans der LQIP (low-quality image placeholder) Methode: wir laden immer ein sehr kleines (typischerweise ~30x20px, blurred, mit quality 10) Platzhalterbild im korrekten Seitenverhältnis des jeweiligen Bildes, um im Layout-Flow den benötigten Platz zu reservieren. Vorteil: beim JS-basierten Nachladen des qualitativ hochwertigen Bildes findet kein Reflow/Springen des Textes statt.

In Sonderfällen kann es aber sinnvoll sein, komplett ohne sofort ladendes Platzhalterbild zu agieren. Ein Beispiel: die Seite "Pressefotos" der Staatsoper. Hier entstehen (Stand November 2018) Requests auf über 1000 (Platzhalter-)Bilder in zunächst eingeklappten Akkordeons im HMTL einer einzigen Seite. "Leider" ist es best practice von Browsern, auch Bilder zu laden, die selbst oder durch ihre Eltern via display: none; ausgeblendet sind. Für genau diesen Fall ist es pragmatisch und besser, auf LQIP zu verzichten und komplett auf JS-lazyloading zu setzen, anstatt >1000 requests auf den thumbor-Server zu jagen. Für Nutzer ohne aktives JS halten wir im `<noscript>`-Element ein Fallback bereit.