### PR TITLE
Alt attribute fuer r img

### DIFF
--- a/Resources/views/Macros/responsiveImg.html.twig
+++ b/Resources/views/Macros/responsiveImg.html.twig
@@ -8,6 +8,7 @@
             'sizes': '100%',
             'transformations_to_widths': {'image_xxs' : '320w'},
             'class': '',
+            'alt' : '',
             'lazyload': true,
             'lqip': true,
             'placeholder_filter': 'image_xxs--blurred',
@@ -23,9 +24,7 @@
                 data-src="{{ thumbor(image.url, options.placeholder_filter) }}"
             {% endif %}
             class="{% if options.lazyload %}lazyload {% endif %}{{ options.class }}"
-            {% if image.alt %}
-                title="{{ image.alt }}"
-            {% endif %}
+            alt="{{ options.alt is not empty ? options.alt : image.alt }}"
             {% if image.title %}
                 title="{{ image.title }}"
             {% endif %}


### PR DESCRIPTION
Bisher fehlte die Möglichkeit bei responsive Images das Alt-Attribut 'händisch' zu befüllen bzw. wurde es auch per Default nicht ausgeben. Jetzt wird immer mindestens ein leeres Alt-Attribut ausgegeben bzw. ein auf Bild-Ebene gepflegtes. Ausserdem kann das Attribut per Options befüllt werden.