### PR TITLE
Make sure default config is actually prepended

### DIFF
--- a/DependencyInjection/WebfactoryResponsiveImageExtension.php
+++ b/DependencyInjection/WebfactoryResponsiveImageExtension.php
@@ -23,7 +23,7 @@ class WebfactoryResponsiveImageExtension extends Extension implements PrependExt
         $bundles = $container->getParameter('kernel.bundles');
 
         if (!isset($bundles['JbPhumborBundle'])) {
-            return;
+            throw new \LogicException('WebfactoryResponsiveImageBundle requires that you also activate JbPhumborBundle (from jbouzekri/phumbor-bundle).');
         }
 
         $config = Yaml::parse(file_get_contents(__DIR__.'/../Resources/config/jb_phumbor-default-config.yaml'));

--- a/DependencyInjection/WebfactoryResponsiveImageExtension.php
+++ b/DependencyInjection/WebfactoryResponsiveImageExtension.php
@@ -26,16 +26,7 @@ class WebfactoryResponsiveImageExtension extends Extension implements PrependExt
             return;
         }
 
-        $this->prependConfigFile(__DIR__.'/../Resources/config/jb_phumbor-default-config.yaml', $container);
-
-        $environment = $container->getParameter('kernel.environment');
-        if (in_array($environment, ['development', 'testing', 'test'], true)) {
-            $this->prependConfigFile(__DIR__."/../Resources/config/jb_phumbor-default-config_$environment.yaml", $container);
-        }
-    }
-
-    private function prependConfigFile(string $filename, ContainerBuilder $container): void
-    {
-        $container->prependExtensionConfig('jb_phumbor', Yaml::parse(file_get_contents($filename))['jb_phumbor']);
+        $config = Yaml::parse(file_get_contents(__DIR__.'/../Resources/config/jb_phumbor-default-config.yaml'));
+        $container->prependExtensionConfig('jb_phumbor', $config['jb_phumbor']);
     }
 }

--- a/Resources/config/jb_phumbor-default-config.yaml
+++ b/Resources/config/jb_phumbor-default-config.yaml
@@ -1,9 +1,5 @@
 # each setting can be overwritten in your application
 jb_phumbor:
-    server:
-        url: '%env(THUMBOR_URL)%'
-        secret: '%env(THUMBOR_SECURITY_KEY)%'
-
     transformations:
         image_thumb:
             resize: { width: 80, height: 0 }
@@ -41,7 +37,6 @@ jb_phumbor:
             resize: { width: 2400, height: 0 }
             filters:
                 - { name: 'quality', arguments: [80] }
-
         image_xxs--squared:
             resize: { width: 320, height: 320 }
             filters:
@@ -70,7 +65,6 @@ jb_phumbor:
             resize: { width: 1600, height: 1600 }
             filters:
                 - { name: 'quality', arguments: [80] }
-
         image_xxs--blurred:
             resize: { width: 320, height: 0 }
             filters:

--- a/Resources/config/jb_phumbor-default-config_development.yaml
+++ b/Resources/config/jb_phumbor-default-config_development.yaml
@@ -1,4 +1,0 @@
-jb_phumbor:
-    server:
-        # local development thumbor does not need a secret
-        secret:

--- a/Resources/config/jb_phumbor-default-config_test.yaml
+++ b/Resources/config/jb_phumbor-default-config_test.yaml
@@ -1,5 +1,0 @@
-# dummy values to cut off external dependencies during automated software tests
-jb_phumbor:
-    server:
-        url: 'http://local-thumbor-dummy'
-        secret:

--- a/Resources/config/jb_phumbor-default-config_testing.yaml
+++ b/Resources/config/jb_phumbor-default-config_testing.yaml
@@ -1,1 +1,0 @@
-# Staging system does not differ from production

--- a/composer.json
+++ b/composer.json
@@ -4,15 +4,13 @@
     "license": "MIT",
     "require": {
         "php": ">=5.5.9",
+        "jbouzekri/phumbor-bundle": "^2.2.0",
         "twig/twig": "^1.35.4|^2.0",
         "symfony/http-kernel": "^3.4.14 | ^4.4.1",
         "symfony/config": "^3.4.14 | ^4.4.1",
         "symfony/dependency-injection": "^3.4.14 | ^4.4.1",
         "symfony/deprecation-contracts": "^2.0",
         "symfony/yaml": "^3.4.14 | ^4.4.1"
-    },
-    "suggest": {
-        "jbouzekri/phumbor-bundle": "Can be auto-configured with default transformations"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
It seems the default config included in this bundle actually overrides the application level config, instead of providing defaults that can be overwritten by the application.

Once https://github.com/jbouzekri/PhumborBundle/pull/17 is merged and fixes config hierarchies for `jb_phumbor`, all we need to do is to prepend the default config.
