### PR TITLE
Add basic video support (Case 126130)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,9 @@ Example:
   - `transformations` (optional): an object with thumbor transformation names as keys and MIME-Types as values. Defaults to 
     ```
     {
-      'video_hevc' : 'video/mp4; codecs=hevc',
-      'video_webm' : 'video/webm; codecs=vp9',
-      'video_mp4': 'video/mp4'
+      'video_hevc_720p' : 'video/mp4; codecs=hevc',
+      'video_webm_720p' : 'video/webm; codecs=vp9',
+      'video_mp4_720p': 'video/mp4'
     }
     ```
   - `class` (optional): CSS classes to add to the image. Defaults to empty string.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,39 @@ Example:
 ) }}
 ```
 
+### Responsive Background Video
+
+`responsiveBackgroundVideo(video, options)` with:
+
+- `video`: an array with the following keys:
+  - `url` (mandatory): the URL of the image
+- `options`: an array with the following keys:
+  - `transformations` (optional): an object with thumbor transformation names as keys and MIME-Types as values. Defaults to 
+    ```
+    {
+      'video_hevc' : 'video/mp4; codecs=hevc',
+      'video_webm' : 'video/webm; codecs=vp9',
+      'video_mp4': 'video/mp4'
+    }
+    ```
+  - `class` (optional): CSS classes to add to the image. Defaults to empty string.
+  - `data_attributes` (optional): an iterable object with data-attribute names (= the part after `data-`) and values as key/value pairs. Defaults to empty string.
+
+Example:
+
+```
+{% import '@WebfactoryResponsiveImageBundle/Macros/responsiveVideo.html.twig' as rVid %}
+
+{{ rVid.responsiveBackgroundVideo(
+    {
+        'url': s3_cachable_url(entity, 'video')
+    },
+    {
+        'class': 'background-video',
+        'data_attributes': {'credits': '© P. H. O'Tographer'},
+    }
+) }}
+```
 
 ## Default Configuration for JbPhumborBundle
 

--- a/Resources/config/jb_phumbor-default-config.yaml
+++ b/Resources/config/jb_phumbor-default-config.yaml
@@ -90,3 +90,39 @@ jb_phumbor:
             filters:
                 - { name: 'blur', arguments: [30] }
                 - { name: 'quality', arguments: [50] }
+        video_hevc_480p:
+            resize: { width: 0, height: 480 }
+            filters:
+                - { name: 'format', arguments: [ 'hevc' ] }
+        video_hevc_720p:
+            resize: { width: 0, height: 720 }
+            filters:
+                - { name: 'format', arguments: [ 'hevc' ] }
+        video_hevc_1080p:
+            resize: { width: 0, height: 1080 }
+            filters:
+                - { name: 'format', arguments: [ 'hevc' ] }
+        video_webm_480p:
+            resize: { width: 0, height: 480 }
+            filters:
+                - { name: 'format', arguments: [ 'webm' ] }
+        video_webm_720p:
+            resize: { width: 0, height: 720 }
+            filters:
+                - { name: 'format', arguments: [ 'webm' ] }
+        video_webm_1080p:
+            resize: { width: 0, height: 1080 }
+            filters:
+                - { name: 'format', arguments: [ 'webm' ] }
+        video_mp4_480p:
+            resize: { width: 0, height: 480 }
+            filters:
+                - { name: 'format', arguments: [ 'mp4' ] }
+        video_mp4_720p:
+            resize: { width: 0, height: 720 }
+            filters:
+                - { name: 'format', arguments: [ 'mp4' ] }
+        video_mp4_1080p:
+            resize: { width: 0, height: 1080 }
+            filters:
+                - { name: 'format', arguments: [ 'mp4' ] }

--- a/Resources/views/Macros/responsiveVideo.html.twig
+++ b/Resources/views/Macros/responsiveVideo.html.twig
@@ -1,0 +1,39 @@
+{% macro responsiveBackgroundVideo(video, options) %}
+    {% if video.url %}
+        {% import _self as helper %}
+
+        {% set defaultVideoOptions = {
+            'transformations': {
+                'video_hevc' : 'video/mp4; codecs=hevc',
+                'video_webm' : 'video/webm; codecs=vp9',
+                'video_mp4': 'video/mp4'
+            },
+            'class': '',
+            'data_attributes': '',
+            'poster': '',
+            'autoplay': true,
+            'loop': true,
+            'muted': true,
+            'playsinline': true,
+        } %}
+
+        {% set options = options ? defaultVideoOptions|merge(options) : defaultVideoOptions %}
+
+        <video
+            {% if options.class %}class="{{ options.class }}"{% endif %}
+            {% if options.autoplay %}autoplay=""{% endif %}
+            {% if options.muted %}muted=""{% endif %}
+            {% if options.loop %}loop=""{% endif %}
+            {% if options.playsinline %}playsinline=""{% endif %}
+            {% if options.data_attributes is not empty %}
+                {% for name, value in options.data_attributes %}
+                    data-{{ name }}="{{ value }}"
+                {% endfor %}
+            {% endif %}
+        >
+            {%- for transformation, type in options.transformations -%}
+                <source src="{{ thumbor(video.url, transformation) }}" type="{{ type }}" />
+            {%- endfor -%}"
+        </video>
+    {% endif %}
+{% endmacro %}

--- a/Resources/views/Macros/responsiveVideo.html.twig
+++ b/Resources/views/Macros/responsiveVideo.html.twig
@@ -4,9 +4,9 @@
 
         {% set defaultVideoOptions = {
             'transformations': {
-                'video_hevc' : 'video/mp4; codecs=hevc',
-                'video_webm' : 'video/webm; codecs=vp9',
-                'video_mp4': 'video/mp4'
+                'video_hevc_720p' : 'video/mp4; codecs=hevc',
+                'video_webm_720p' : 'video/webm; codecs=vp9',
+                'video_mp4_720p': 'video/mp4'
             },
             'class': '',
             'data_attributes': '',


### PR DESCRIPTION
Uses our self-hosted Thumbor (extended with a video engine in webfactory/webfactory-de-thumbor#2), to display short videos as GIF alternative. The videos are muted and looping infinitely by default. The macro uses three different video codecs by default (HEVC, WebM, MP4).