### PR TITLE
Gebe alt-Attirbut für picture immer aus (Case 147073)

### DIFF
--- a/Resources/views/Macros/responsiveImg.html.twig
+++ b/Resources/views/Macros/responsiveImg.html.twig
@@ -102,9 +102,7 @@
                     data-src="{{ thumbor(image_url, options.placeholder_filter) }}"
                 {% endif %}
                 class="{% if options.lazyload %}lazyload {% endif %}{{ options.class }}"
-                {% if options.alt %}
-                    alt="{{ options.alt }}"
-                {% endif %}
+                alt="{{ options.alt }}"
                 {% if options.title %}
                     title="{{ options.title }}"
                 {% endif %}


### PR DESCRIPTION
- Um im Rahmen der Barrierefreiheit für Screenreader zu kommunizieren,
  dass es sich bei dem Bild um ein rein dekoratives Bild handelt, muss
  ein alt-Attribut mitgegeben werden, dieses aber leer sein.