### PR TITLE
Add support for exposing a focal point via CSS Custom Properties (Case 168230)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ If you intend to use lazyloading for images (which is the default), require `"la
     - `placeholder_filter`: a string with the name of the thumbor transformation (i.e. `image_lqip`) which is added to the placeholder image when lazyloading the image. Should match the target dimensions of the image. A list of default transformations is provided with this bundle (see below) and can be overwritten / extended in the application configuration, e.g. the config.yml.
     - `lazyload` (optional): Use lazyloading. Defaults to `true`.
     - `lqip` (optional): Use the LQIP-method ([original concept (2013)](https://www.guypo.com/introducing-lqip-low-quality-image-placeholders), [current popular LQIP options](https://cloudinary.com/blog/low_quality_image_placeholders_lqip_explained)) of always loading a low-quality placeholder image. Defaults to `true`.
+    - `focal_point` (optional): An object with `x` and `y` properties that contain integer values. This bundles exposes the focal point via CSS Custom Properties on `<img>`; those Custom Properties can be used to mark the area that should be cropped last when the image is cropped via `object-fit`. The project using this bundle needs to add `object-position: var(--focal-x, center) var(--focal-y, top);` or similar to the image styles. This will interpret the focal point if one was selected in the CMS or fall back to the comma-separated values (which can be any length or keyword that is valid for `object-position`).
 
 Example:
  
@@ -78,6 +79,7 @@ Example:
     - `placeholder_filter`: a string with the name of the thumbor transformation (i.e. `image_lqip`) which is added to the placeholder image when lazyloading the image. Should match the target dimensions of the image. A list of default transformations is provided with this bundle (see below) and can be overwritten / extended in the application configuration, e.g. the config.yml.
     - `lazyload` (optional): Use lazyloading. Defaults to `true`.
     - `lqip` (optional): Use the LQIP-method ([original concept (2013)](https://www.guypo.com/introducing-lqip-low-quality-image-placeholders), [current popular LQIP options](https://cloudinary.com/blog/low_quality_image_placeholders_lqip_explained)) of always loading a low-quality placeholder image. Defaults to `true`.
+    - `focal_point` (optional): An object with `x` and `y` properties that contain integer values. This bundles exposes the focal point via CSS Custom Properties on `<img>`; those Custom Properties can be used to mark the area that should be cropped last when the image is cropped via `object-fit`. The project using this bundle needs to add `object-position: var(--focal-x, center) var(--focal-y, top);` or similar to the image styles. This will interpret the focal point if one was selected in the CMS or fall back to the comma-separated values (which can be any length or keyword that is valid for `object-position`).
 
 Example:
  

--- a/Resources/views/Macros/responsiveImg.html.twig
+++ b/Resources/views/Macros/responsiveImg.html.twig
@@ -9,6 +9,7 @@
             'transformations_to_widths': {'image_xxxs' : '160w', 'image_xxs' : '320w', 'image_xs': '480w', 'image_s': '600w', 'image_md' : '992w', 'image_lg' : '1200w', 'image_xl' : '1600w'},
             'class': '',
             'data_attributes': '',
+            'style': '',
             'alt' : '',
             'title': '',
             'lazyload': true,
@@ -35,6 +36,9 @@
                     data-{{ name }}="{{ value }}"
                 {% endfor %}
             {% endif %}
+            {% if options.style is not empty %}
+                style="{{ options.style }}"
+            {% endif %}
         />
 
         <noscript>
@@ -49,6 +53,9 @@
                     {% for name, value in options.data_attributes %}
                         data-{{ name }}="{{ value }}"
                     {% endfor %}
+                {% endif %}
+                {% if options.style is not empty %}
+                    style="{{ options.style }}"
                 {% endif %}
             />
         </noscript>
@@ -67,6 +74,7 @@
         'lqip': true,
         'placeholder_filter': 'image_lqip',
         'data_attributes': '',
+        'focal_point': null
     } %}
 
     {% set defaultFormatOptions = {
@@ -110,6 +118,9 @@
                     {% for name, value in options.data_attributes %}
                         data-{{ name }}="{{ value }}"
                     {% endfor %}
+                {% endif %}
+                {% if options.focal_point and options.focal_point.x and options.focal_point.y %}
+                    style="--focal-x: {{ options.focal_point.x ~ '%' }}; --focal-y: {{ options.focal_point.y ~ '%' }};"
                 {% endif %}
             />
         {% endif %}

--- a/Resources/views/Macros/responsiveImg.html.twig
+++ b/Resources/views/Macros/responsiveImg.html.twig
@@ -9,12 +9,12 @@
             'transformations_to_widths': {'image_xxxs' : '160w', 'image_xxs' : '320w', 'image_xs': '480w', 'image_s': '600w', 'image_md' : '992w', 'image_lg' : '1200w', 'image_xl' : '1600w'},
             'class': '',
             'data_attributes': '',
-            'style': '',
             'alt' : '',
             'title': '',
             'lazyload': true,
             'lqip': true,
             'placeholder_filter': 'image_lqip',
+            'focal_point': null
         } %}
         {% set options = options ? defaultImgOptions|merge(options) : defaultImgOptions %}
 
@@ -36,8 +36,8 @@
                     data-{{ name }}="{{ value }}"
                 {% endfor %}
             {% endif %}
-            {% if options.style is not empty %}
-                style="{{ options.style }}"
+            {% if options.focal_point and options.focal_point.x and options.focal_point.y %}
+                style="--focal-x: {{ options.focal_point.x ~ '%' }}; --focal-y: {{ options.focal_point.y ~ '%' }};"
             {% endif %}
         />
 
@@ -54,8 +54,8 @@
                         data-{{ name }}="{{ value }}"
                     {% endfor %}
                 {% endif %}
-                {% if options.style is not empty %}
-                    style="{{ options.style }}"
+                {% if options.focal_point and options.focal_point.x and options.focal_point.y %}
+                    style="--focal-x: {{ options.focal_point.x ~ '%' }}; --focal-y: {{ options.focal_point.y ~ '%' }};"
                 {% endif %}
             />
         </noscript>


### PR DESCRIPTION
This PR exposes given focal point coordinates (`{ x: 0, y: 0 }`) via CSS Custom Properties on `<img>`. The data can be used in CSS `object-position` to declare the area that should be cropped last when the image is cropped via `object-fit`.