### PR TITLE
Aktualisiere die Anforderungen an Dependencies auf halbwegs aktuelle Versionen

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,12 +3,12 @@
     "description": "Symfony bundle for responsive images",
     "license": "MIT",
     "require": {
-        "php": "^7.2|^8.0",
-        "jbouzekri/phumbor-bundle": "^2.2.0|^3.0",
-        "twig/twig": "^1.35.4|^2.0|^3.0",
-        "symfony/config": "^3.4.14|^4.4.1|^5.0|^6.0|^7.0",
-        "symfony/dependency-injection": "^3.4.14|^4.4.1|^5.0|^6.0|^7.0",
-        "symfony/yaml": "^3.4.14|^4.4.1|^5.0|^6.0|^7.0"
+        "php": ">= 8.1",
+        "jbouzekri/phumbor-bundle": "^2.2.0|^3.0|^4.0",
+        "twig/twig": "^2.0|^3.0",
+        "symfony/config": "^5.4|^6.4|^7.3",
+        "symfony/dependency-injection": "^5.4|^6.4|^7.3",
+        "symfony/yaml": "^5.4|^6.4|^7.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Das PhumborBundle ^4.0 selbst ist schon für Symfony 8 vorbereitet.